### PR TITLE
Make echo'd keysize match value entered.

### DIFF
--- a/pgp/01-creating.md
+++ b/pgp/01-creating.md
@@ -1,4 +1,3 @@
-
 ```
 $ gpg --gen-key
 
@@ -22,7 +21,7 @@ What keysize do you want? (2048)
 
 
 ```
-Requested keysize is 4096 bits
+Requested keysize is 2048 bits
 Please specify how long the key should be valid.
          0 = key does not expire
       <n>  = key expires in n days


### PR DESCRIPTION
On line 19 it says (2048) which seems to indicate that the default that will be selected is 2048. Since nothing is entered after the prompt, it is assumed that this is what the demo user used. However the next line is incongruous when it reports that the keysize is "4096 bits".

This CL fixes that.
