### PR TITLE
Make it clear that the chosen key size is 4096.

### DIFF
--- a/pgp/01-creating.md
+++ b/pgp/01-creating.md
@@ -17,7 +17,7 @@ Your selection?
 
 ```
 RSA keys may be between 1024 and 4096 bits long.
-What keysize do you want? (2048)
+What keysize do you want? (2048) 4096
 ```
 
 


### PR DESCRIPTION
As it was, it looked like the default option (2048) was chosen, but then subsequent commands use 4096 as the keysize. This fixes that.
